### PR TITLE
fix: Only return certificates that are owned by the user

### DIFF
--- a/src/certificate/certificate.controller.ts
+++ b/src/certificate/certificate.controller.ts
@@ -104,8 +104,8 @@ export class CertificateController {
 
         const userCertificates = certificates.filter(
             (cert) =>
-                BigNumber.from(cert.owners[blockchainAddress]) > BigNumber.from(0) ||
-                BigNumber.from(cert.claimers[blockchainAddress]) > BigNumber.from(0)
+                BigNumber.from(cert.owners[blockchainAddress] ?? 0) > BigNumber.from(0) ||
+                BigNumber.from(cert.claimers[blockchainAddress] ?? 0) > BigNumber.from(0)
         );
 
         return Promise.all(


### PR DESCRIPTION
### Problem

Calling `/api/certificate` and specifying a blockchain address still returns all the certificates instead of only the ones owned by the blockchain address.

### Solution

Only return certificates that the user has ownership of or claimed.