### PR TITLE
fix: Send some EWT to generated blockchain accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,4 @@ DB_DATABASE=ute-issuer
 # Amount of energy in single certificate
 ENERGY_PER_UNIT=1
 DEFAULT_ENERGY_IN_BASE_UNIT=1
+MIN_ETHER_BALANCE=0.01

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -1,6 +1,7 @@
 import { BlockchainPropertiesService } from '@energyweb/issuer-api';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Wallet } from 'ethers';
+import { ConfigService } from '@nestjs/config';
+import { Wallet, utils } from 'ethers';
 import { Contracts as IssuerContracts } from '@energyweb/issuer';
 import { getProviderWithFallback } from '@energyweb/utils-general';
 
@@ -12,22 +13,36 @@ export class AccountService {
     constructor(
         @InjectRepository(Account)
         private readonly repository: Repository<Account>,
-        private readonly blockchainPropertiesService: BlockchainPropertiesService
+        private readonly blockchainPropertiesService: BlockchainPropertiesService,
+        private readonly configService: ConfigService
     ) {}
 
     public async create(): Promise<AccountDTO> {
         const totalAccounts = await this.repository.count();
 
+        const { registry, rpcNode, platformOperatorPrivateKey } =
+            await this.blockchainPropertiesService.get();
+        const provider = getProviderWithFallback(rpcNode);
+        const issuerAccount = new Wallet(platformOperatorPrivateKey, provider);
+
+        const minBalanceNeeded = utils.parseEther(
+            this.configService.get<string>('MIN_ETHER_BALANCE') || '0.01'
+        );
+
         const newAccount = Wallet.fromMnemonic(
             process.env.MNEMONIC,
             `m/44'/60'/0'/0/${totalAccounts + 1}`
         );
+        const newAccountBalance = await newAccount.connect(provider).getBalance();
 
-        const { registry, rpcNode, platformOperatorPrivateKey } =
-            await this.blockchainPropertiesService.get();
-        const provider = getProviderWithFallback(rpcNode);
+        if (newAccountBalance.lte(minBalanceNeeded)) {
+            const fillUpTx = await issuerAccount.sendTransaction({
+                to: newAccount.address,
+                value: minBalanceNeeded
+            });
 
-        const issuerAccount = new Wallet(platformOperatorPrivateKey);
+            await fillUpTx.wait();
+        }
 
         const registryWithSigner = IssuerContracts.factories.RegistryFactory.connect(
             registry,


### PR DESCRIPTION
Send some EWT to generated blockchain accounts if their balance is less than minimum required to do the approval transaction.